### PR TITLE
Handle returned messages from channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm Downloads](https://img.shields.io/npm/dm/rabbot.svg?style=flat)](https://www.npmjs.com/package/rabbot)
 [![Dependencies](https://img.shields.io/david/LeanKit-Labs/rabbot.svg?style=flat)](https://david-dm.org/LeanKit-Labs/rabbot)
 
-This is a very opinionated abstraction over amqplib to help simplify certain common tasks and (hopefully) reduce the effort required to use RabbitMQ in your Node services. 
+This is a very opinionated abstraction over amqplib to help simplify certain common tasks and (hopefully) reduce the effort required to use RabbitMQ in your Node services.
 
 > !Important! - successful use of this library requires a conceptual knowledge of AMQP and an understanding of RabbitMQ.
 
@@ -89,7 +89,7 @@ rabbot will stop trying to connect/re-connect if either of these thresholds is r
 rabbot provides the ability to define multiple nodes per connections by supplying either a comma delimited list or array of server IPs or names to the `host` property. You can also specify multuple ports in the same way but make certain that either you provide a single port for all servers or that the number of ports matches the number and order of servers.
 
 ### Shutting Down
-Both exchanges and queues have asynchronous processes that work behind the scenes processing publish confirms and batching message acknowledgements. To shutdown things in a clean manner, rabbot provides a `shutdown` method that returns a promise which will resolve once all outstanding confirmations and batching have completed and the connection is closed. 
+Both exchanges and queues have asynchronous processes that work behind the scenes processing publish confirms and batching message acknowledgements. To shutdown things in a clean manner, rabbot provides a `shutdown` method that returns a promise which will resolve once all outstanding confirmations and batching have completed and the connection is closed.
 
 ### Events
 rabbot emits both generic and specific connectivity events that you can bind to in order to handle various states:
@@ -156,7 +156,7 @@ Things to remember when publishing a message:
 This example shows all of the available properties (including those which get set by default):
 
 ```javascript
-rabbit.publish( "exchange.name", 
+rabbit.publish( "exchange.name",
 	{
 		routingKey: "hi",
 		type: "company.project.messages.textMessage",
@@ -166,6 +166,7 @@ rabbit.publish( "exchange.name",
 		messageId: "100",
 		expiresAfter: 1000 // TTL in ms, in this example 1 second
 		timestamp: // posix timestamp (long)
+		mandatory: true, //Must be set to true for onReturned to receive unqueued message
 		headers: {
 			random: "application specific value"
 		},
@@ -220,7 +221,7 @@ If using the second format, the options hash can contain the following propertie
 }
 ```
 
-> Notes: 
+> Notes:
 > * using options without a `queue` or `type` specified will handle _all_ messages received by the service because of the defaults.
 > * the behavior here differs in that exceptions are handled for you _by default_
 
@@ -307,6 +308,16 @@ Rejects unhandled messages so that will will _not_ be requeued. **DO NOT** use t
 rabbit.rejectUnhandled();
 ```
 
+### Returned Messages
+Unroutable messages that were published with `mandatory: true` will be returned. These messages cannot be ack/nack'ed.
+
+#### onReturned( handler )
+```javascript
+rabbit.onReturned( function( message ) {
+	 // the returned message
+} );
+```
+
 ### startSubscription( queueName, [exclusive], [connectionName] )
 
 > Recommendation: set handlers for anticipated types up before starting subscriptions.
@@ -360,7 +371,7 @@ Enqueues the message for rejection. This will re-enqueue the message.
 Rejects the message without re-queueing it. Please use with caution and consider having a dead-letter-exchange assigned to the queue before using this feature.
 
 ### message.reply( message, [options] )
-Acknowledges the messages and sends the message back to the requestor. The `message` is only the body of the reply. 
+Acknowledges the messages and sends the message back to the requestor. The `message` is only the body of the reply.
 
 The options hash can specify additional information about the reply and has the following properties (defaults shown:
 

--- a/spec/behavior/topology.spec.js
+++ b/spec/behavior/topology.spec.js
@@ -89,7 +89,7 @@ describe( "Topology", function() {
 				bindQueue: noOp
 			};
 			controlMock = sinon.mock( control );
-			
+
 			var uniqueQueueName = "top-q-" + info.createHash();
 			controlMock
 				.expects( "bindQueue" )
@@ -100,7 +100,7 @@ describe( "Topology", function() {
 				.once()
 				.resolves( control );
 
-			topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue, "test" );
+			topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue, "test" );
 			when.all( [
 					topology.createExchange( { name: "top-ex", type: "topic" } ),
 					topology.createQueue( { name: "top-q", unique: "hash" } )
@@ -142,7 +142,7 @@ describe( "Topology", function() {
 					bindQueue: noOp
 				};
 				controlMock = sinon.mock( control );
-				
+
 				var uniqueQueueName = "top-q-" + info.createHash();
 				controlMock
 					.expects( "bindExchange" )
@@ -207,7 +207,7 @@ describe( "Topology", function() {
 					subscribe: true
 				}
 			};
-			topology = topologyFn( conn.instance, options, {}, undefined, Exchange, Queue, "test" );
+			topology = topologyFn( conn.instance, options, {}, undefined, undefined, Exchange, Queue, "test" );
 			topology.once( "replyQueue.ready", function( queue ) {
 				replyQueue = queue;
 				done();
@@ -271,7 +271,7 @@ describe( "Topology", function() {
 			var options = {
 				replyQueue: false
 			};
-			topology = topologyFn( conn.instance, options, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, options, {}, undefined, undefined, Exchange, Queue );
 			topology.once( "replyQueue.ready", function( queue ) {
 				replyQueue = queue;
 				done();
@@ -307,7 +307,7 @@ describe( "Topology", function() {
 				return q;
 			};
 			conn = connectionFn();
-			topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
 			topology.createExchange( { name: "noice" } )
 				.then( function( created ) {
 					exchange = created;
@@ -346,7 +346,7 @@ describe( "Topology", function() {
 				return q;
 			};
 			conn = connectionFn();
-			topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
 			topology.createExchange( { name: "noice" } );
 			topology.createExchange( { name: "noice" } )
 				.then( function( created ) {
@@ -387,7 +387,7 @@ describe( "Topology", function() {
 				return q;
 			};
 			conn = connectionFn();
-			topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
 			topology.createExchange( { name: "badtimes" } )
 				.then( null, function( err ) {
 					error = err;
@@ -423,7 +423,7 @@ describe( "Topology", function() {
 				return q;
 			};
 			conn = connectionFn();
-			topology = topologyFn( conn.instance, { replyQueue: false }, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, { replyQueue: false }, {}, undefined, undefined, Exchange, Queue );
 			topology.createQueue( { name: "badtimes" } )
 				.then( null, function( err ) {
 					error = err;
@@ -469,7 +469,7 @@ describe( "Topology", function() {
 			conn.mock.expects( "getChannel" )
 				.once()
 				.resolves( control );
-			topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
 			topology.createExchange( { name: "noice" } )
 				.then( function( created ) {
 					exchange = created;
@@ -518,7 +518,7 @@ describe( "Topology", function() {
 			conn.mock.expects( "getChannel" )
 				.once()
 				.resolves( control );
-			topology = topologyFn( conn.instance, { replyQueue: false }, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, { replyQueue: false }, {}, undefined, undefined, Exchange, Queue );
 
 			process.nextTick( function() {
 				q.raise( "defined" );
@@ -566,7 +566,7 @@ describe( "Topology", function() {
 			conn.mock.expects( "getChannel" )
 				.once()
 				.resolves( control );
-			topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
 			return topology.createBinding( { source: "from", target: "to" } );
 		} );
 
@@ -603,7 +603,7 @@ describe( "Topology", function() {
 			conn.mock.expects( "getChannel" )
 				.once()
 				.resolves( control );
-			topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue );
+			topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
 			topology.createBinding( { source: "from", target: "to", keys: [ "a.*", "b.*" ], queue: true } );
 		} );
 
@@ -628,7 +628,7 @@ describe( "Topology", function() {
 					return q;
 				};
 				conn = connectionFn();
-				topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue );
+				topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
 				process.nextTick( function() {
 					conn.instance.fail( new Error( "no such server!" ) );
 				} );
@@ -661,7 +661,7 @@ describe( "Topology", function() {
 					return q;
 				};
 				conn = connectionFn();
-				topology = topologyFn( conn.instance, {}, {}, undefined, Exchange, Queue );
+				topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
 				process.nextTick( function() {
 					conn.instance.fail( new Error( "no such server!" ) );
 				} );

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -681,9 +681,9 @@ describe( "Integration Test Suite", function() {
 	describe( "with unroutable messages", function() {
 		var harness;
 		before( function( done ) {
-			harness = harnessFn( done, 1 );
-			rabbit.publish( "rabbot-ex.direct", { routingKey: "completely.un.routable.1", body: "returned message #1" } );
-			rabbit.publish( "rabbot-ex.direct", { routingKey: "completely.un.routable.2", body: "returned message #2" } );
+			harness = harnessFn( done, 2 );
+			rabbit.publish( "rabbot-ex.direct", { mandatory: true, routingKey: "completely.un.routable.1", body: "returned message #1" } );
+			rabbit.publish( "rabbot-ex.direct", { mandatory: true, routingKey: "completely.un.routable.2", body: "returned message #2" } );
 		} );
 
 		it( "should capture messages returned by Rabbit", function() {

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -5,9 +5,10 @@ var harnessFactory = function( rabbit, cb, expected ) {
 	var handlers = [];
 	var received = [];
 	var unhandled = [];
+	var returned = [];
 	expected = expected || 1;
 	var check = function() {
-		if ( ( received.length + unhandled.length ) === expected ) {
+		if ( ( received.length + unhandled.length + returned.length ) === expected ) {
 			cb();
 		}
 	};
@@ -30,7 +31,7 @@ var harnessFactory = function( rabbit, cb, expected ) {
 			options.handler = wrap( options.handler || defaultHandle );
 			handlers.push( rabbit.handle( options ) );
 		} else {
-			handlers.push( rabbit.handle( type, wrap( handle || defaultHandle ), queueName ) );	
+			handlers.push( rabbit.handle( type, wrap( handle || defaultHandle ), queueName ) );
 		}
 	}
 
@@ -48,6 +49,11 @@ var harnessFactory = function( rabbit, cb, expected ) {
 		check();
 	} );
 
+	rabbit.onReturned( function( message ) {
+		returned.push( message );
+		check();
+	} );
+
 	return {
 		add: function( msg ) {
 			received.push( msg );
@@ -57,7 +63,8 @@ var harnessFactory = function( rabbit, cb, expected ) {
 		clean: clean,
 		handle: handleFn,
 		handlers: handlers,
-		unhandled: unhandled
+		unhandled: unhandled,
+		returned: returned
 	};
 };
 
@@ -663,6 +670,30 @@ describe( "Integration Test Suite", function() {
 					{ body: "one", queue: "rabbot-q.general1" },
 					{ body: "three", queue: "rabbot-q.general1" },
 					{ body: "two", queue: "rabbot-q.general1" }
+				] );
+		} );
+
+		after( function() {
+			harness.clean();
+		} );
+	} );
+
+	describe( "with unroutable messages", function() {
+		var harness;
+		before( function( done ) {
+			harness = harnessFn( done, 1 );
+			rabbit.publish( "rabbot-ex.topic", { routingKey: "completely.un.routable", body: "uh oh" } );
+		} );
+
+		it( "should capture messages returned by Rabbit", function() {
+			var results = _.map( harness.returned, function( m ) {
+				return {
+					body: m.body
+				};
+			} );
+			results.should.eql(
+				[
+					{ body: "uh oh" }
 				] );
 		} );
 

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -682,18 +682,21 @@ describe( "Integration Test Suite", function() {
 		var harness;
 		before( function( done ) {
 			harness = harnessFn( done, 1 );
-			rabbit.publish( "rabbot-ex.topic", { routingKey: "completely.un.routable", body: "uh oh" } );
+			rabbit.publish( "rabbot-ex.direct", { routingKey: "completely.un.routable.1", body: "returned message #1" } );
+			rabbit.publish( "rabbot-ex.direct", { routingKey: "completely.un.routable.2", body: "returned message #2" } );
 		} );
 
 		it( "should capture messages returned by Rabbit", function() {
 			var results = _.map( harness.returned, function( m ) {
 				return {
+					type: m.type,
 					body: m.body
 				};
 			} );
 			results.should.eql(
 				[
-					{ body: "uh oh" }
+					{ body: "returned message #1", type: "completely.un.routable.1" },
+					{ body: "returned message #2", type: "completely.un.routable.2" }
 				] );
 		} );
 

--- a/src/amqp/exchange.js
+++ b/src/amqp/exchange.js
@@ -77,7 +77,7 @@ function publish( channel, options, topology, log, serializers, message ) {
 		appId: message.appId || info.id,
 		headers: message.headers || {},
 		expiration: message.expiresAfter || undefined,
-		mandatory: true
+		mandatory: message.mandatory || false
 	};
 	if ( publishOptions.replyTo === "amq.rabbitmq.reply-to" ) {
 		publishOptions.headers[ "direct-reply-to" ] = "true";

--- a/src/amqp/exchange.js
+++ b/src/amqp/exchange.js
@@ -76,7 +76,8 @@ function publish( channel, options, topology, log, serializers, message ) {
 		timestamp: message.timestamp || Date.now(),
 		appId: message.appId || info.id,
 		headers: message.headers || {},
-		expiration: message.expiresAfter || undefined
+		expiration: message.expiresAfter || undefined,
+		mandatory: true
 	};
 	if ( publishOptions.replyTo === "amq.rabbitmq.reply-to" ) {
 		publishOptions.headers[ "direct-reply-to" ] = "true";

--- a/src/connectionFsm.js
+++ b/src/connectionFsm.js
@@ -13,6 +13,7 @@ var log = require( "./log.js" )( "rabbot.connection" );
 	'reconnected' - lost connection recovered
 	'failed' - connection lost
 	'unreachable' - no end points could be reached within threshold
+ 	'return' - published message was returned by AMQP
 */
 
 /* logs:
@@ -65,6 +66,9 @@ var Connection = function( options, connectionFn, channelFn ) {
 						this._onChannel.bind( this, name, context );
 						resolve( channel );
 					}.bind( this ) );
+					channel.on( "return", function(raw) {
+						this.emit( "return", raw);
+					}.bind(this));
 				}.bind( this ) );
 			} else {
 				return when( channel );


### PR DESCRIPTION
Functionality to handle messages that were published to RabbitMQ but returned via the channel's `return` event.

Return event documentation:
http://www.squaremobius.net/amqp.node/channel_api.html#channel_events