### PR TITLE
Ability to update routing keys on queue binding

### DIFF
--- a/src/topology.js
+++ b/src/topology.js
@@ -160,13 +160,16 @@ Topology.prototype.configureExchanges = function( exchangeDef, list ) {
 
 Topology.prototype.createBinding = function( options ) {
 	var id = [ options.source, options.target ].join( "->" );
+	var keys = getKeys( options.keys );
+	if ( keys.length > 1 || keys[0] !== "" ) {
+		id += ":" + keys.join(':');
+	}
 	var promise = this.promises[ id ];
 	if( !promise ) {
 		this.definitions.bindings[ id ] = options;
 		var call = options.queue ? "bindQueue" : "bindExchange";
 		var source = options.source;
 		var target = options.target;
-		var keys = getKeys( options.keys );
 		this.promises[ id ] = promise = this.connection.getChannel( "control", false, "control channel for bindings" )
 			.then( function( channel ) {
 				log.info( "Binding %s '%s' to '%s' on '%s' with keys: %s",

--- a/src/topology.js
+++ b/src/topology.js
@@ -161,7 +161,7 @@ Topology.prototype.configureExchanges = function( exchangeDef, list ) {
 Topology.prototype.createBinding = function( options ) {
 	var id = [ options.source, options.target ].join( "->" );
 	var keys = getKeys( options.keys );
-	if ( keys.length > 1 || keys[0] !== "" ) {
+	if ( keys[0] !== "" ) {
 		id += ":" + keys.join(':');
 	}
 	var promise = this.promises[ id ];


### PR DESCRIPTION
This implements the feature requested in #16 

I've updated `createBinding` to include the routing keys in the binding ID. This allows a user to call the `bindQueue` method multiple times with new routing keys to update the binding. 

I modified the tests to update the test for `createBinding`. I also noticed that the test was called "when creating an exchange to queue binding with no keys" but the binding *did* include keys. I made a copy of the test creating a binding without keys so now there's tests for binding to a queue both with and without keys.