### PR TITLE
return the Promise that was promised (by the docs) ?

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,12 +92,11 @@ Broker.prototype.addConnection = function( options ) {
 			this.emit( "return", raw);
 		}.bind( this ) );
 		this.connections[ name ] = topology;
-		return topology;
 	} else {
-		connection = this.connections[ name ];
-		connection.connection.connect();
-		return connection;
+		topology = this.connections[ name ];
 	}
+	
+	return topology.connection.connect();
 };
 
 Broker.prototype.addExchange = function( name, type, options, connectionName ) {


### PR DESCRIPTION
This gives an example of returning the Promise (that the docs say `addConnection()` should be returning) ... is this what the intention was? what of the fact that the `Topology` instance is no longer returned? do users need/want to have that instance exposed (or should it actually be hidden as an implementation detail)?