### PR TITLE
Convert number to string in options body.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -274,6 +274,9 @@ Broker.prototype.publish = function( exchangeName, type, message, routingKey, co
 	if( connection.publishTimeout ) {
 		options.connectionPublishTimeout = connection.publishTimeout;
 	}
+	if ( _.isNumber( options.body ) ) {
+    options.body = options.body.toString();
+  }
 	return this.getExchange( exchangeName, connectionName )
 		.publish( options );
 };


### PR DESCRIPTION
Just a short cut to supplement converting a number to string as robbot
can only accept a string, object, or buffer.