### PR TITLE
Inject servername into amqplib

### DIFF
--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -157,7 +157,7 @@ Adapter.prototype.connect = function() {
 				}
 			}
 			if ( _.indexOf( attempted, nextUri ) < 0 ) {
-				amqp.connect( nextUri, this.options )
+				amqp.connect( nextUri, Object.assign( { servername: url.parse(nextUri).hostname }, this.options ))
 					.then( onConnection.bind( this ), onConnectionError.bind( this ) );
 			} else {
 				log.info( "Cannot connect to `%s` - all endpoints failed", this.name );


### PR DESCRIPTION
Where there are multiple SSL secured Rabbits on a server, SNI is required to identify correct certificates. This change injects (without modifying) the connection options with the required `servername` from the Uri on making the connection.