### PR TITLE
Fix memory leak by disabling routing key caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ Options is a hash that can contain the following:
  * limit 			2^16			max number of unacked messages allowed for consumer
  * noAck			true|false 		the server will remove messages from the queue as soon as they are delivered
  * noBatch			true|false 		causes ack, nack & reject to take place immediately
+ * noCacheKeys		true|false 		disable cache of matched routing keys to prevent unbounded memory growth
  * queueLimit		2^32			max number of ready messages a queue can hold
  * messageTtl		2^32			time in ms before a message expires on the queue
  * expires			2^32			time in ms before a queue with 0 consumers expires

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "lodash": "^4.15.0",
     "machina": "^2.0.0",
     "monologue.js": "^0.3.5",
-    "postal": "^2.0.4",
+    "postal": "^2.0.5",
     "uuid": "^3.0.0",
     "when": "^3.7.7",
     "whistlepunk": "^0.3.2"

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -11,6 +11,9 @@ var topLog = require( "../log" )( "rabbot.topology" );
 var unhandledLog = require( "../log" )( "rabbot.unhandled" );
 var noOp = function() {};
 
+// Disable routing key caching to prevent memory leak
+postal.configuration.resolverNoCache = true
+
 /* log
 	* `rabbot.amqp-queue`
 	  * `debug`

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -11,9 +11,6 @@ var topLog = require( "../log" )( "rabbot.topology" );
 var unhandledLog = require( "../log" )( "rabbot.unhandled" );
 var noOp = function() {};
 
-// Disable routing key caching to prevent memory leak
-postal.configuration.resolverNoCache = true
-
 /* log
 	* `rabbot.amqp-queue`
 	  * `debug`
@@ -241,6 +238,7 @@ function resolveTags( channel, queue, connection ) {
 function subscribe( channelName, channel, topology, serializers, messages, options, exclusive ) {
 	var shouldAck = !options.noAck;
 	var shouldBatch = !options.noBatch;
+	var shouldCacheKeys = !options.noCacheKeys
   // this is done to support rabbit-assigned queue names
   channelName = channelName || options.name
 	if ( shouldAck && shouldBatch ) {
@@ -324,6 +322,9 @@ function subscribe( channelName, channel, topology, serializers, messages, optio
 		} else {
 			dispatch.publish( {
 				topic: topic,
+				headers: {
+					resolverNoCache: !shouldCacheKeys
+				},
 				data: raw
 			}, onPublish );
 		}


### PR DESCRIPTION
By default the postal routing key cache is never cleared. That is effectively a memory leak when a large
number of routing keys is used.