### PR TITLE
Fixed deserialize property name typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ The deserialize function takes both the raw bytes and the encoding sent. While "
 var yaml = require( "js-yaml" );
 
 rabbit.addSerializer( "application/yaml", {
-	deserializer: function( bytes, encoding ) {
+	deserialize: function( bytes, encoding ) {
 		return yaml.safeLoad( bytes.toString( encoding || "utf8" ) );
 	},
 	serialize: function( object ) {


### PR DESCRIPTION
The custom deserializer function should be provided as the 'deserialize' property and not the 'deserializer' property.

Fixed the typo in the documentation.