### PR TITLE
Fix unhandledRejection warnings in tests

### DIFF
--- a/spec/behavior/topology.spec.js
+++ b/spec/behavior/topology.spec.js
@@ -604,7 +604,8 @@ describe( "Topology", function() {
 				.once()
 				.resolves( control );
 			topology = topologyFn( conn.instance, {}, {}, undefined, undefined, Exchange, Queue );
-			topology.createBinding( { source: "from", target: "to", keys: undefined, queue: true } );
+			topology.createBinding( { source: "from", target: "to", keys: undefined, queue: true } )
+				.catch( _.noop );
 		} );
 
 		it( "should add binding to definitions", function() {

--- a/spec/integration/integration.spec.js
+++ b/spec/integration/integration.spec.js
@@ -149,7 +149,7 @@ describe( "Integration Test Suite", function() {
 						server: "shfifty-five.gov",
 						publishTimeout: 50,
 						timeout: 500
-					} );
+					} ).catch( _.noop );
 
 					rabbit.addExchange( { name: "silly-ex" }, "silly" ).then( null, _.noop );
 				} );


### PR DESCRIPTION
Some test cases have promises without catch handlers, which causes node to emit unhandledRejection events.