### PR TITLE
Fix for #72 - Ability to send persistent messages with "no name" default exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Things to remember when publishing a message:
  * If `body` is a Buffer, it will be sent as a byte array and `contentType` will be "application/octet-stream"
  * By default, the type specifier will be used if no routing key is undefined
  * Use a routing key of `""` to prevent the type specifier from being used as the routing key
+ * Non-persistent messages in a queue will be lost on server restart, default is non-persistent.  Persistence can be set on either an exchange when it is created via addExchange, or when sending a message (needed when using "default" exchanges since non-persistent publish is the default)
 
 This example shows all of the available properties (including those which get set by default):
 
@@ -179,6 +180,7 @@ rabbit.publish( "exchange.name",
 		expiresAfter: 1000 // TTL in ms, in this example 1 second
 		timestamp: // posix timestamp (long)
 		mandatory: true, //Must be set to true for onReturned to receive unqueued message
+		persistent: true, //If either message or exchange defines persistent=true queued messages will be saved to disk.
 		headers: {
 			random: "application specific value"
 		},

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
     "gulp": "^3.9.0",
+    "request": "^2.79.0",
     "sinon": "^1.17.2",
     "sinon-as-promised": "^4.0.0"
   },

--- a/src/amqp/exchange.js
+++ b/src/amqp/exchange.js
@@ -90,7 +90,7 @@ function publish( channel, options, topology, log, serializers, message ) {
 	if ( !message.sequenceNo ) {
 		log.add( message );
 	}
-	if ( options.persistent ) {
+	if ( options.persistent || message.persistent ) {
 		publishOptions.persistent = true;
 	}
 


### PR DESCRIPTION
This is the proposed fix for #72 , it adds an optional "persistent" value when publishing a message, if either the exchange OR the message says to make the message persistent it makes it so when published.