### PR TITLE
Fix for options being undefined in addExchange

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,10 +121,8 @@ Broker.prototype.addConnection = function( options ) {
 };
 
 Broker.prototype.addExchange = function( name, type, options, connectionName ) {
+	options = options || {};
 	connectionName = connectionName || "default";
-  if( !type && !options ) {
-    options = {};
-  }
 	if ( _.isObject( name ) ) {
 		options = name;
 		connectionName = type;


### PR DESCRIPTION
When calling the `rabbit.addExchange()` function passing in the first parameter of name and the second parameter of type e.g. `rabbit.addExchange(exchangeName, 'topic')` this was generating an error of:
`TypeError: Cannot set property 'name' of undefined
    at Broker.addExchange (\node_modules\rabbot\src\index.js:132:16)`

This was due to the addExchange function trying to assign name to `options.name`, however, `options` was undefined.

This has been fixed by removing the if statement checking for both `type` and `options` to not exist before assigning `options` to an empty object and instead assigning `options` to either the passed in options argument or an empty object at the top level of the function.