### PR TITLE
Create a default empty config object in config.js

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ var log = require( "./log" )( "rabbot.configuration" );
 var logger;
 module.exports = function( Broker ) {
 	Broker.prototype.configure = function( config ) {
+    config = config || {};
 		if( !logger && config.logging ) {
 			logger = require( "./log" )( config.logging || {} );
 		}


### PR DESCRIPTION
When running retry() without having used rabbit.configure( settings ), config.js throws an error because it tries to access config.logging while config is undefined. 

This pull request adds a line to create an empty object if for config if it is undefined to prevent this error.