### PR TITLE
expose the client-provided connection name for RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Options is a hash that can contain the following:
  * `uri` - the AMQP URI. No default. This will be parsed and missing defaults will be supplied.
  * `name` - the name of this connection. Defaults to `"default"`.
  * `host` - the IP address or DNS name of the RabbitMQ server. Defaults to `"localhost"`.
+* `tcpName` - expose the client-provided connection name (shown below the ip address on the rabbitMQ's adminitration panel)
  * `port` - the TCP/IP port on which RabbitMQ is listening. Defaults to `5672`.
  * `vhost` - the named vhost to use in RabbitMQ. Defaults to the root vhost, `"%2f"` ("/").
  * `protocol` - the connection protocol to use. Defaults to "amqp://".

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -83,6 +83,7 @@ var Adapter = function( parameters ) {
 	var brokers = getOption( parameters, "RABBIT_BROKER" );
 	var serverList = brokers || hosts || servers || "localhost";
 	var portList = getOption( parameters, "RABBIT_PORT" ) || getOption( parameters, "port", 5672 );
+	var tcpName = getOption( parameters, "tcpName" );
 
 	this.name = parameters ? ( parameters.name || "default" ) : "default";
 	this.connectionIndex = 0;
@@ -130,6 +131,9 @@ var Adapter = function( parameters ) {
 		process: info.process(),
 		lib: info.lib()
 	};
+	if ( tcpName ) {
+		this.options.clientProperties.connection_name = tcpName;
+	}
 	this.limit = _.max( [ this.servers.length, this.ports.length ] );
 };
 


### PR DESCRIPTION
Hello, 
This parameter is usefull for simply naming rabbitMQ connections origin.

![rabbit-screen](https://user-images.githubusercontent.com/4386903/28938952-fe90c4ba-788f-11e7-9621-6a4a47268b6b.jpg)
