### PR TITLE
Propagate 'failed' event from channel to connection

### DIFF
--- a/src/connectionFsm.js
+++ b/src/connectionFsm.js
@@ -66,9 +66,12 @@ var Connection = function( options, connectionFn, channelFn ) {
 						this._onChannel.bind( this, name, context );
 						resolve( channel );
 					}.bind( this ) );
+					channel.on( "failed", function(err) {
+						this.emit( "failed", err )
+					}.bind( this ));
 					channel.on( "return", function(raw) {
-						this.emit( "return", raw);
-					}.bind(this));
+						this.emit( "return", raw );
+					}.bind( this ));
 				}.bind( this ) );
 			} else {
 				return when( channel );


### PR DESCRIPTION
Using a clustered RabbitMQ with 3 nodes, restarting one of them may trigger a channel error such as:

```bash
2017-10-19T17:35:22.916Z [rabbot.io] Error emitted by channel 'control' - 'Error: Channel closed by server: 404 (NOT-FOUND) with message "NOT_FOUND - no exchange 'stg_auth-queue' in vhost '/'"ode_modules/amqplib/lib/channel.js:406:17)
    at Connection.mainAccept [as accept] (/opt/sst/services/sst.auth/node_modules/amqplib/lib/connection.js:63:33)
    at Socket.go (/opt/sst/services/sst.auth/node_modules/amqplib/lib/connection.js:476:48)
    at emitNone (events.js:86:13)
    at Socket.emit (events.js:185:7)
    at emitReadable_ (_stream_readable.js:432:10)
    at emitReadable (_stream_readable.js:426:7)
    at readableAddChunk (_stream_readable.js:187:13)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:547:20)'
You have triggered an unhandledRejection, you may have forgotten to catch a Promise rejection:
Error: Operation failed: ExchangeBind; 404 (NOT-FOUND) with message "NOT_FOUND - no exchange 'stg_auth-queue' in vhost '/'"
    at reply (/opt/sst/services/sst.auth/node_modules/amqplib/lib/channel.js:127:17)
    at Channel.C.accept (/opt/sst/services/sst.auth/node_modules/amqplib/lib/channel.js:401:7)
    at Connection.mainAccept [as accept] (/opt/sst/services/sst.auth/node_modules/amqplib/lib/connection.js:63:33)
    at Socket.go (/opt/sst/services/sst.auth/node_modules/amqplib/lib/connection.js:476:48)
    at emitNone (events.js:86:13)
    at Socket.emit (events.js:185:7)
    at emitReadable_ (_stream_readable.js:432:10)
    at emitReadable (_stream_readable.js:426:7)
    at readableAddChunk (_stream_readable.js:187:13)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:547:20)
```

We have the following 'failed' handler:

```javascript
rabbit.on('failed', () => {
    process.exit(1);
});
```

to make sure our services restart automatically if any failure would happen.

However in the case of a channel error, this wasn't triggered and the process continued to run in a bad state, not consuming its queues anymore. I didn't find a way to catch the above error since rabbot seems to hide the concept of channels behind the scenes.

This change makes sure to propagate a 'failed' event occurring on a channel to the connection. This fixed our issue, ensuring our services will restart in such a case.

I'm not entirely sure if this could have other side effects, but to me this feels better than not being able to catch this type of errors at all :)