### PR TITLE
changed contentEncoding for messages to be standard compliant

### DIFF
--- a/src/amqp/exchange.js
+++ b/src/amqp/exchange.js
@@ -79,7 +79,7 @@ function publish (channel, options, topology, log, serializers, message) {
   var publishOptions = {
     type: message.type || '',
     contentType: contentType,
-    contentEncoding: 'utf8',
+    contentEncoding: 'UTF-8',
     correlationId: message.correlationId || '',
     replyTo: message.replyTo || topology.replyQueue.name || '',
     messageId: message.messageId || message.id || '',

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -138,7 +138,7 @@ function getReply (channel, serializers, raw, replyQueue, connectionName) {
       var publishOptions = {
         type: replyType,
         contentType: contentType,
-        contentEncoding: 'utf8',
+        contentEncoding: 'UTF-8',
         correlationId: raw.properties.messageId,
         timestamp: options && options.timestamp ? options.timestamp : Date.now(),
         replyTo: replyQueue === false ? undefined : replyQueue,


### PR DESCRIPTION
as per
http://www.iana.org/assignments/character-sets/character-sets.xhtml
utf8 does not exist.

when publishing messages as JSON-RPC a proper implemented server rejects the message as invalid due the invalid content encoding

```
const hrTime = process.hrtime();
rabbot.publish( "service.rpc", {
    type: "ping",
    contentType: "application/json",
    body: { ping: hrTime[0] * 1000 + hrTime[1] / 1000000 },
    headers: {
      jsonrpc: "2.0",
    },
}
```