### PR TITLE
Refined content detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file. See [standa
 <a name="2.1.0"></a>
 # [2.1.0](https://github.com/arobson/rabbot/compare/v1.1.0...v2.1.0) (2018-02-18)
 
+### Changed
+* Moved lodash to normal depencencies from dev dependencies
+* Bump nodejs version to 4 from 6
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
       "url": "http://derickbailey.com/"
     },
     {
+      "name": "Randy Groff",
+      "url": "http://randygroff.com"
+    },
+    {
+      "name": "Joseph Frazier",
+      "url": "https://github.com/josephfrazier"
+    },
+    {
       "name": "Mario Kozjak",
       "url": "https://github.com/mkozjak"
     },
@@ -48,12 +56,52 @@
       "url": "https://github.com/brianedgerton"
     },
     {
+      "name": "Ryan Niemeyer",
+      "url": "http://knockmeout.net"
+    },
+    {
       "name": "Jim Cowart",
       "url": "http://github.com/ifandelse"
     },
     {
+      "name": "Sean Corrales",
+      "url": "https://github.com/droidenator"
+    },
+    {
+      "name": "Matthew Martin",
+      "url": "http://matmar10.com"
+    },
+    {
+      "name": "Tom Kirkpatrick",
+      "url": "https://github.com/mrfelton"
+    },
+    {
+      "name": "Bill Matson",
+      "url": "https://github.com/bmatson"
+    },
+    {
+      "name": "Scott Walters",
+      "url": "http://github.com/LeankitScott"
+    },
+    {
+      "name": "Eric Satterwhite",
+      "url": "http://codedependant.net/"
+    },
+    {
+      "name": "Leonardo Bispo de Oliveira",
+      "url": "http://blog.bispooliveira.de"
+    },
+    {
+      "name": "Michael Tuttle",
+      "url": "https://github.com/openam"
+    },
+    {
       "name": "John Mathis",
       "url": "http://github.com/JohnDMathis"
+    },
+    {
+      "name": "Dj Walker-Morgan",
+      "url": "http://www.codepope.com"
     },
     {
       "name": "Austin Young",

--- a/spec/integration/subscription.spec.js
+++ b/spec/integration/subscription.spec.js
@@ -38,6 +38,8 @@ describe('Duplicate Subscription', function () {
     }).then(() => {
       harness.handle('topic');
       rabbit.startSubscription('rabbot-q.subscription');
+      rabbit.publish('rabbot-ex.subscription', { type: 'topic', routingKey: 'this.is.an.array', body: [1, 2, 3] });
+      rabbit.publish('rabbot-ex.subscription', { type: 'topic', routingKey: 'this.is.an.object', body: {foo: 'bar'} });
       rabbit.publish('rabbot-ex.subscription', { type: 'topic', routingKey: 'this.is.a.test', body: 'broadcast' });
       rabbit.publish('rabbot-ex.subscription', { type: 'topic', routingKey: 'this.is.sparta', body: 'leonidas' });
       rabbit.publish('rabbot-ex.subscription', { type: 'topic', routingKey: 'this.is.not.wine.wtf', body: 'socrates' });
@@ -54,6 +56,8 @@ describe('Duplicate Subscription', function () {
     );
     sortBy(results, 'body').should.eql(
       [
+        { body: [1, 2, 3], key: 'this.is.an.array' },
+        { body: {foo: 'bar'}, key: 'this.is.an.object' },
         { body: 'broadcast', key: 'this.is.a.test' },
         { body: 'leonidas', key: 'this.is.sparta' },
         { body: 'socrates', key: 'this.is.not.wine.wtf' }

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -69,7 +69,7 @@ function getContentType (body, options) {
     return options.contentType;
   } else if (typeof body === 'string') {
     return 'text/plain';
-  } else if (typeof body === 'object' && !body.length) {
+  } else if (typeof body === 'object' && !Buffer.isBuffer(body)) {
     return 'application/json';
   } else {
     return 'application/octet-stream';


### PR DESCRIPTION
When you send an array in publish or request, it's for the subscriber not possible to decipher it because it will be considered a buffer (octet stream).
Writing array structures as json seems a valid pattern but the serializer would not allow it and limit a user of rabbot to wrap array structure in an object body.

This PR also contains tests for these changes in the subscriber.