### PR TITLE
fix: add mandatory offset

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -22,7 +22,7 @@ function createConsumerTag (queueName) {
 
 function hash (id) {
   var bytes = crypto.createHash('md4').update(id).digest();
-  var num = toBE ? bytes.readdInt16BE() : bytes.readInt16LE();
+  var num = toBE ? bytes.readdInt16BE(0) : bytes.readInt16LE(0);
   return num < 0 ? Math.abs(num) + 0xffffffff : num;
 }
 


### PR DESCRIPTION
In Node.js 10.x passing in the offset is mandatory. This makes sure everything continues to work as it should.

Refs: https://github.com/nodejs/node/pull/18395