### PR TITLE
Fix issue with overriding configuration parameters

### DIFF
--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -92,9 +92,21 @@ function trim (x) {
   return x.trim(' ');
 }
 
+function skipNull (params) {
+  return Object.keys (params || {})
+    .filter(function (key) {
+      const value = params[key]
+      return value !== null && value !== undefined
+    })
+    .reduce(function (acc, key) {
+      acc[key] = params[key]
+      return acc
+    }, {})
+}
+
 const Adapter = function (parameters) {
   var uriOpts = parseUri(parameters.uri);
-  Object.assign(parameters, uriOpts);
+  Object.assign(parameters, skipNull(uriOpts));
   const hosts = getOption(parameters, 'host');
   const servers = getOption(parameters, 'server');
   const brokers = getOption(parameters, 'RABBIT_BROKER');

--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -93,15 +93,15 @@ function trim (x) {
 }
 
 function skipNull (params) {
-  return Object.keys (params || {})
+  return Object.keys(params || {})
     .filter(function (key) {
-      const value = params[key]
-      return value !== null && value !== undefined
+      const value = params[key];
+      return value !== null && value !== undefined;
     })
     .reduce(function (acc, key) {
-      acc[key] = params[key]
-      return acc
-    }, {})
+      acc[key] = params[key];
+      return acc;
+    }, {});
 }
 
 const Adapter = function (parameters) {


### PR DESCRIPTION
Let's assume that we have the following code:
```js
const rabbot = require('rabbot')
rabbot.addConnection({
  uri: 'amqp://localhost',
  user: 'not-guest',
  pass: 'super-secret'
}
```
Without this fix the following happens:

- `uri` is parsed
- `uriOpts` contains a `null` value for `user`
- a `null` value for `user` from `uriOpts` is applied over valid `user` value from configuration via `Object.assign`
- `getOption` is called to assign value for `this.user`
- and `this.user` will always be `guest`, because `parameters.user` is `null` at this time

Proposed PR filter out all nullable properties from `uriOpts` before applying it over `parameters`, which prevents overriding valid properties from configuration.