### PR TITLE
Separation of rabbot instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
 FROM rabbitmq:3-management
 
+COPY docker_files/rabbitmq.config /etc/rabbitmq/
+
+COPY docker_files/custom_definitions.json /etc/rabbitmq/
+
 RUN rabbitmq-plugins enable --offline rabbitmq_consistent_hash_exchange

--- a/docker_files/custom_definitions.json
+++ b/docker_files/custom_definitions.json
@@ -1,0 +1,25 @@
+{
+    "users": [{
+        "name": "guest",
+        "password": "guest",
+        "tags": "administrator"
+    }],
+    "vhosts": [{
+        "name": "/"
+    }, {
+        "name": "/different"
+    }],
+    "permissions": [{
+        "user": "guest",
+        "vhost": "/",
+        "configure": ".*",
+        "write": ".*",
+        "read": ".*"
+    }, {
+        "user": "guest",
+        "vhost": "/different",
+        "configure": ".*",
+        "write": ".*",
+        "read": ".*"
+    }]
+}

--- a/docker_files/rabbitmq.config
+++ b/docker_files/rabbitmq.config
@@ -1,0 +1,18 @@
+[
+  {rabbit,
+    [
+      { tcp_listeners, [ 5672 ] },
+      { ssl_listeners, [ ] },
+      {loopback_users, []}
+    ]
+  },
+  { rabbitmq_management, [
+      {load_definitions, "/etc/rabbitmq/custom_definitions.json"},
+      { listener, [
+        { port, 15672 },
+        { ssl, false }
+        ]
+      }
+    ]
+  }
+].

--- a/spec/behavior/ackBatch.spec.js
+++ b/spec/behavior/ackBatch.spec.js
@@ -1,6 +1,6 @@
 require('../setup.js');
 var postal = require('postal');
-var signal = postal.channel('rabbit.ack');
+const uuid = require('uuid');
 var AckBatch = require('../../src/ackBatch.js');
 var noOp = function () {};
 
@@ -9,7 +9,8 @@ describe('Ack Batching', function () {
     var batch;
     var messageData;
     before(function () {
-      batch = new AckBatch('test-queue', 'test-connection', noOp);
+      const pubSubNamespace = uuid.v4();
+      batch = new AckBatch('test-queue', 'test-connection', noOp, { pubSubNamespace });
       messageData = batch.getMessageOps(101);
       batch.addMessage(messageData);
     });
@@ -58,7 +59,9 @@ describe('Ack Batching', function () {
         status = s;
         done();
       };
-      batch = new AckBatch('test-queue', 'test-connection', resolver);
+      const pubSubNamespace = uuid.v4();
+      const signal = postal.channel(`rabbit.ack.${pubSubNamespace}`);
+      batch = new AckBatch('test-queue', 'test-connection', resolver, { pubSubNamespace });
       batch.listenForSignal();
       signal.publish('go', {});
     });
@@ -85,7 +88,9 @@ describe('Ack Batching', function () {
         status = s;
         done();
       };
-      batch = new AckBatch('test-queue', 'test-connection', resolver);
+      const pubSubNamespace = uuid.v4();
+      const signal = postal.channel(`rabbit.ack.${pubSubNamespace}`);
+      batch = new AckBatch('test-queue', 'test-connection', resolver, { pubSubNamespace });
       batch.addMessage({ tag: 101, status: 'pending' });
       batch.addMessage({ tag: 102, status: 'pending' });
       batch.addMessage({ tag: 103, status: 'pending' });
@@ -125,7 +130,9 @@ describe('Ack Batching', function () {
         status = s;
         done();
       };
-      batch = new AckBatch('test-queue', 'test-connection', resolver);
+      const pubSubNamespace = uuid.v4();
+      const signal = postal.channel(`rabbit.ack.${pubSubNamespace}`);
+      batch = new AckBatch('test-queue', 'test-connection', resolver, { pubSubNamespace });
       batch.addMessage({ tag: 101, status: 'pending' });
       batch.addMessage({ tag: 102, status: 'pending' });
       batch.addMessage({ tag: 103, status: 'ack' });
@@ -168,7 +175,9 @@ describe('Ack Batching', function () {
         data = d;
         return Promise.resolve(true);
       };
-      batch = new AckBatch('test-queue', 'test-connection', resolver);
+      const pubSubNamespace = uuid.v4();
+      const signal = postal.channel(`rabbit.ack.${pubSubNamespace}`);
+      batch = new AckBatch('test-queue', 'test-connection', resolver, { pubSubNamespace });
       batch.on('empty', function () {
         done();
       });
@@ -219,7 +228,9 @@ describe('Ack Batching', function () {
         data = d;
         return Promise.resolve(true);
       };
-      batch = new AckBatch('test-queue', 'test-connection', resolver);
+      const pubSubNamespace = uuid.v4();
+      const signal = postal.channel(`rabbit.ack.${pubSubNamespace}`);
+      batch = new AckBatch('test-queue', 'test-connection', resolver, { pubSubNamespace });
       batch.on('empty', function () {
         done();
       });
@@ -270,7 +281,9 @@ describe('Ack Batching', function () {
         data = d;
         return Promise.resolve(true);
       };
-      batch = new AckBatch('test-queue', 'test-connection', resolver);
+      const pubSubNamespace = uuid.v4();
+      const signal = postal.channel(`rabbit.ack.${pubSubNamespace}`);
+      batch = new AckBatch('test-queue', 'test-connection', resolver, { pubSubNamespace });
       batch.on('empty', function () {
         done();
       });
@@ -322,7 +335,9 @@ describe('Ack Batching', function () {
         data.push(d);
         return Promise.resolve(true);
       };
-      batch = new AckBatch('test-queue', 'test-connection', resolver);
+      const pubSubNamespace = uuid.v4();
+      const signal = postal.channel(`rabbit.ack.${pubSubNamespace}`);
+      batch = new AckBatch('test-queue', 'test-connection', resolver, { pubSubNamespace });
       batch.on('empty', function () {
         done();
       });

--- a/spec/behavior/topology.spec.js
+++ b/spec/behavior/topology.spec.js
@@ -97,7 +97,7 @@ describe('Topology', function () {
         .once()
         .resolves(control);
 
-      topology = topologyFn(conn.instance, {}, {}, undefined, undefined, Exchange, Queue, 'test');
+      topology = topologyFn(conn.instance, { pubSubNamespace: 'test' }, {}, undefined, undefined, Exchange, Queue, 'test');
       Promise.all([
         topology.createExchange({ name: 'top-ex', type: 'topic' }),
         topology.createQueue({ name: 'top-q', unique: 'hash' })
@@ -119,6 +119,7 @@ describe('Topology', function () {
         {
           name: 'test.response.queue',
           uniqueName: 'test.response.queue',
+          pubSubNamespace: 'test',
           autoDelete: true,
           subscribe: true
         }
@@ -167,6 +168,7 @@ describe('Topology', function () {
           {
             name: 'test.response.queue',
             uniqueName: 'test.response.queue',
+            pubSubNamespace: 'test',
             autoDelete: true,
             subscribe: true
           }
@@ -202,7 +204,8 @@ describe('Topology', function () {
           uniqueName: 'mine',
           autoDelete: false,
           subscribe: true
-        }
+        },
+        pubSubNamespace: 'test'
       };
       topology = topologyFn(conn.instance, options, {}, undefined, undefined, Exchange, Queue, 'test');
       topology.once('replyQueue.ready', function (queue) {
@@ -219,6 +222,7 @@ describe('Topology', function () {
         {
           name: 'mine',
           uniqueName: 'mine',
+          pubSubNamespace: 'test',
           autoDelete: false,
           subscribe: true
         }
@@ -240,6 +244,7 @@ describe('Topology', function () {
           {
             name: 'mine',
             uniqueName: 'mine',
+            pubSubNamespace: 'test',
             autoDelete: false,
             subscribe: true
           }

--- a/spec/integration/badConnection.spec.js
+++ b/spec/integration/badConnection.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 
 describe('Bad Connection', function () {
   const noop = () => {};

--- a/spec/integration/bulkPublish.spec.js
+++ b/spec/integration/bulkPublish.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/configuration.js
+++ b/spec/integration/configuration.js
@@ -8,6 +8,15 @@ module.exports = {
     vhost: '%2f',
     replyQueue: 'customReplyQueue'
   },
+  differentVhost: {
+    name: 'differentVhost',
+    user: 'guest',
+    pass: 'guest',
+    host: '127.0.0.1',
+    port: 5672,
+    vhost: '%2fdifferent',
+    replyQueue: 'customReplyQueue'
+  },
 
   noReplyQueue: {
     name: 'noReplyQueue',

--- a/spec/integration/connection.spec.js
+++ b/spec/integration/connection.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('Connection', function () {

--- a/spec/integration/connection.spec.js
+++ b/spec/integration/connection.spec.js
@@ -15,7 +15,8 @@ describe('Connection', function () {
     });
 
     it('should assign uri to connection', function () {
-      connected.uri.should.equal('amqp://guest:guest@127.0.0.1:5672/%2f?heartbeat=30');
+      const con = config.connection;
+      connected.uri.should.equal(`amqp://${con.user}:${con.pass}@${con.host}:${con.port}/${con.vhost}?heartbeat=30`);
     });
 
     after(function () {

--- a/spec/integration/consistentHash.spec.js
+++ b/spec/integration/consistentHash.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('Consistent Hash Exchange', function () {

--- a/spec/integration/directReplyQueue.spec.js
+++ b/spec/integration/directReplyQueue.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe(`Direct Reply Queue (replyQueue: 'rabbit')`, function () {

--- a/spec/integration/fanout.spec.js
+++ b/spec/integration/fanout.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('Fanout Exchange With Multiple Subscribed Queues', function () {

--- a/spec/integration/instance.spec.js
+++ b/spec/integration/instance.spec.js
@@ -1,0 +1,116 @@
+require('../setup');
+const Rabbit = require('../../src/index.js');
+const config = require('./configuration');
+
+const firstRabbit = new Rabbit();
+const secondRabbit = new Rabbit();
+
+const configs = {
+  instance_1: {
+    connection: config.connection,
+    exchanges: [
+      {
+        name: 'rabbot-ex.subscription',
+        type: 'topic',
+        alternate: 'rabbot-ex.alternate',
+        autoDelete: true
+      }
+    ],
+    queues: [
+      {
+        name: 'rabbot-q.subscription',
+        autoDelete: true,
+        subscribe: true,
+        deadletter: 'rabbot-ex.deadletter'
+      }
+    ],
+    bindings: [
+      {
+        exchange: 'rabbot-ex.subscription',
+        target: 'rabbot-q.subscription',
+        keys: 'this.is.#'
+      }
+    ]
+  },
+  instance_2: {
+    connection: config.differentVhost,
+    exchanges: [
+      {
+        name: 'rabbot-ex.subscription',
+        type: 'topic',
+        alternate: 'rabbot-ex.alternate',
+        autoDelete: true
+      }
+    ],
+    queues: [
+      {
+        name: 'rabbot-q.subscription',
+        autoDelete: true,
+        subscribe: true,
+        deadletter: 'rabbot-ex.deadletter'
+      }
+    ],
+    bindings: [
+      {
+        exchange: 'rabbot-ex.subscription',
+        target: 'rabbot-q.subscription',
+        keys: 'this.is.#'
+      }
+    ]
+  }
+};
+
+describe('Multiple Instances', function () {
+  var firstHarness, secondHarness;
+
+  before(function (done) {
+    new Promise(function (resolve, reject) {
+      firstRabbit.configure(configs.instance_1).then(() => {
+        firstHarness.handle('topic');
+        firstRabbit.startSubscription('rabbot-q.subscription');
+        firstRabbit.publish('rabbot-ex.subscription', { type: 'topic', routingKey: 'this.is.a.test', body: 'broadcast' });
+      });
+
+      firstHarness = harnessFactory(firstRabbit, resolve, 1);
+    }).then(function () {
+      secondRabbit.configure(configs.instance_2).then(() => {
+        secondHarness.handle('topic');
+        secondRabbit.startSubscription('rabbot-q.subscription', false, 'differentVhost');
+        secondRabbit.publish('rabbot-ex.subscription', { type: 'topic', routingKey: 'this.is.a.different.test', body: 'broadcast' }, 'differentVhost');
+        secondRabbit.publish('rabbot-ex.subscription', { type: 'topic', routingKey: 'this.is.a.different.test2', body: 'broadcast' }, 'differentVhost');
+      });
+
+      secondHarness = harnessFactory(secondRabbit, done, 1);
+    });
+  });
+
+  it('should not recieve the same message', function () {
+    const filterMsg = (m) =>
+      ({
+        body: m.body,
+        key: m.fields.routingKey
+      });
+
+    const firstResults = firstHarness.received.map(filterMsg);
+    const secondResults = secondHarness.received.map(filterMsg);
+
+    sortBy(firstResults, 'body').should.eql(
+      [
+        { body: 'broadcast', key: 'this.is.a.test' }
+      ]
+    );
+
+    sortBy(secondResults, 'body').should.eql(
+      [
+        { body: 'broadcast', key: 'this.is.a.different.test' },
+        { body: 'broadcast', key: 'this.is.a.different.test2' }
+      ]
+    );
+  });
+
+  after(function () {
+    return firstHarness.clean('default').then(function () {
+      return secondHarness.clean('differentVhost');
+    });
+  });
+});

--- a/spec/integration/mandatory.spec.js
+++ b/spec/integration/mandatory.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/noReplyQueue.spec.js
+++ b/spec/integration/noReplyQueue.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('No Reply Queue (replyQueue: false)', function () {

--- a/spec/integration/noack.spec.js
+++ b/spec/integration/noack.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('Message Acknowledgments Disabled (noAck: true)', function () {

--- a/spec/integration/nobatch.spec.js
+++ b/spec/integration/nobatch.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('Batch Acknowledgments Disabled (noBatch: true)', function () {

--- a/spec/integration/poisonMessages.spec.js
+++ b/spec/integration/poisonMessages.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/publish.spec.js
+++ b/spec/integration/publish.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 
 describe('Publishing Messages', function () {
   describe('without a connection defined', function () {

--- a/spec/integration/purgeQueue.spec.js
+++ b/spec/integration/purgeQueue.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/queueSpecificHandle.spec.js
+++ b/spec/integration/queueSpecificHandle.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/randomQueue.spec.js
+++ b/spec/integration/randomQueue.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/rejection.spec.js
+++ b/spec/integration/rejection.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/request.spec.js
+++ b/spec/integration/request.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('Request & Response', function () {

--- a/spec/integration/subscription.spec.js
+++ b/spec/integration/subscription.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/topicExchange.spec.js
+++ b/spec/integration/topicExchange.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/typeSpecific.spec.js
+++ b/spec/integration/typeSpecific.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/typeless.spec.js
+++ b/spec/integration/typeless.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/spec/integration/unhandled.spec.js
+++ b/spec/integration/unhandled.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('Unhandled Strategies', function () {

--- a/spec/integration/unrouted.spec.js
+++ b/spec/integration/unrouted.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 describe('Unroutable Messages - Alternate Exchanges', function () {

--- a/spec/integration/wildCardTypes.spec.js
+++ b/spec/integration/wildCardTypes.spec.js
@@ -1,5 +1,6 @@
 require('../setup');
-const rabbit = require('../../src/index.js');
+const Rabbit = require('../../src/index.js');
+const rabbit = new Rabbit();
 const config = require('./configuration');
 
 /*

--- a/src/ackBatch.js
+++ b/src/ackBatch.js
@@ -1,6 +1,5 @@
 const postal = require('postal');
 const Monologue = require('monologue.js');
-const signal = postal.channel('rabbit.ack');
 const log = require('./log.js')('rabbot.acknack');
 
 /* log
@@ -21,10 +20,12 @@ const calls = {
   reject: '_reject'
 };
 
-const AckBatch = function (name, connectionName, resolver) {
+const AckBatch = function (name, connectionName, resolver, options) {
   this.name = name;
   this.connectionName = connectionName;
   this.resolver = resolver;
+  this.options = options || {};
+  this.signal = postal.channel(`rabbit.ack.${options.pubSubNamespace}`);
   this.reset();
 };
 
@@ -251,7 +252,7 @@ AckBatch.prototype.ignoreSignal = function () {
 
 AckBatch.prototype.listenForSignal = function () {
   if (!this.signalSubscription) {
-    this.signalSubscription = signal.subscribe('#', () => {
+    this.signalSubscription = this.signal.subscribe('#', () => {
       this._processBatch();
     });
   }

--- a/src/amqp/exchange.js
+++ b/src/amqp/exchange.js
@@ -76,6 +76,7 @@ function publish (channel, options, topology, log, serializers, message) {
     return Promise.reject(new Error(errMessage));
   }
   var payload = serializer.serialize(message.body);
+  var timestamp = Math.floor(Date.now()/1000);
   var publishOptions = {
     type: message.type || '',
     contentType: contentType,
@@ -83,7 +84,7 @@ function publish (channel, options, topology, log, serializers, message) {
     correlationId: message.correlationId || '',
     replyTo: message.replyTo || topology.replyQueue.name || '',
     messageId: message.messageId || message.id || '',
-    timestamp: message.timestamp || Date.now(),
+    timestamp: message.timestamp || timestamp,
     appId: message.appId || info.id,
     headers: message.headers || {},
     expiration: message.expiresAfter || undefined,

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -46,13 +46,18 @@ function define (channel, options, subscriber, connectionName) {
   }, 'subscribe', 'limit', 'noBatch', 'unique');
   topLog.info("Declaring queue '%s' on connection '%s' with the options: %s",
     options.uniqueName, connectionName, JSON.stringify(options));
-  return channel.assertQueue(options.uniqueName, valid)
-    .then(function (q) {
-      if (options.limit) {
-        channel.prefetch(options.limit);
-      }
-      return q;
-    });
+
+  if (options.passive){
+    return channel.checkQueue(options.uniqueName);
+  } else {
+    return channel.assertQueue(options.uniqueName, valid)
+      .then(function (q) {
+        if (options.limit) {
+          channel.prefetch(options.limit);
+        }
+        return q;
+      });
+  }
 }
 
 function finalize (channel, messages) {

--- a/src/amqp/queue.js
+++ b/src/amqp/queue.js
@@ -128,6 +128,7 @@ function getReply (channel, serializers, raw, replyQueue, connectionName) {
     var replyType = options ? (options.replyType || defaultReplyType) : defaultReplyType;
     var contentType = getContentType(reply, options);
     var serializer = serializers[ contentType ];
+    var timestamp = Math.floor(Date.now()/1000);
     if (!serializer) {
       var message = format('Failed to publish message with contentType %s - no serializer defined', contentType);
       log.error(message);
@@ -143,7 +144,7 @@ function getReply (channel, serializers, raw, replyQueue, connectionName) {
         contentType: contentType,
         contentEncoding: 'utf8',
         correlationId: raw.properties.messageId,
-        timestamp: options && options.timestamp ? options.timestamp : Date.now(),
+        timestamp: options && options.timestamp ? options.timestamp : timestamp,
         replyTo: replyQueue === false ? undefined : replyQueue,
         headers: options && options.headers ? options.headers : {}
       };

--- a/src/index.js
+++ b/src/index.js
@@ -180,10 +180,11 @@ Broker.prototype.bulkPublish = function (set, connectionName = DEFAULT) {
   if (!this.connections[ connectionName ]) {
     return Promise.reject(new Error(`BulkPublish failed - no connection ${connectionName} has been configured`));
   }
+  var timestamp = Math.floor(Date.now()/1000);
 
   const publish = (exchange, options) => {
     options.appId = options.appId || this.appId;
-    options.timestamp = options.timestamp || Date.now();
+    options.timestamp = options.timestamp || timestamp;
     if (this.connections[ connectionName ] && this.connections[ connectionName ].options.publishTimeout) {
       options.connectionPublishTimeout = this.connections[ connectionName ].options.publishTimeout;
     }
@@ -383,7 +384,7 @@ Broker.prototype.onReturned = function (handler) {
 };
 
 Broker.prototype.publish = function (exchangeName, type, message, routingKey, correlationId, connectionName, sequenceNo) {
-  const timestamp = Date.now();
+  const timestamp = Math.floor(Date.now()/1000);
   let options;
   if (typeof type === 'object') {
     options = type;

--- a/src/index.js
+++ b/src/index.js
@@ -548,6 +548,4 @@ require('./config.js')(Broker);
 
 Monologue.mixInto(Broker);
 
-var broker = new Broker();
-
-module.exports = broker;
+module.exports = Broker;

--- a/src/topology.js
+++ b/src/topology.js
@@ -232,6 +232,7 @@ Topology.prototype.createExchange = function (options) {
 
 Topology.prototype.createQueue = function (options) {
   options.uniqueName = this.getUniqueName(options);
+  options.pubSubNamespace = this.options.pubSubNamespace;
   return this.createPrimitive(Queue, 'queue', options);
 };
 


### PR DESCRIPTION
The main bulk of this pull req is making the in memory pub-sub library use a namespace containing a generated uuid when rabbot is instantiated.
issue ref #172  