### PR TITLE
Export Broker class in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -551,3 +551,4 @@ Monologue.mixInto(Broker);
 var broker = new Broker();
 
 module.exports = broker;
+module.exports.Broker = Broker;


### PR DESCRIPTION
It would be nice to be able to create multiple brokers in the same Node
process, eg. in unit tests. Current implementation prevents this by only
exporting a global Broker instance.

Exporting the Broker class allows it to be instantiated multiple times.