### PR TITLE
fix: bind released method to "this" context to properly access this.name on local scope

### DIFF
--- a/src/amqp/iomonad.js
+++ b/src/amqp/iomonad.js
@@ -145,7 +145,7 @@ module.exports = function (options, type, factory, target, close) {
         }.bind(this));
         this.once('released', function () {
           reject(new Error(`Cannot reacquire released ${type} '${this.name}'`));
-        });
+        }.bind(this));
       }.bind(this));
     },
     operate: function (call, args) {


### PR DESCRIPTION
Hi!
This PR is fixing a bug that happens when the iomonad.js `released` event is fired. It's necessary to bind the released function so it can properly access the name property in the context, otherwise `this` will be undefined on the local scope and throw a type error.

![53371423-f7c9ff00-392e-11e9-9ed2-0352da68a527](https://user-images.githubusercontent.com/2022343/53449345-5a3b0200-39f8-11e9-8803-b6cd2d4237b5.png)
