### PR TITLE
fix retrival of CA from caPaths

### DIFF
--- a/src/amqp/connection.js
+++ b/src/amqp/connection.js
@@ -135,9 +135,7 @@ const Adapter = function (parameters) {
   }
   if (caPaths) {
     const list = caPaths.split(',');
-    this.options.ca = list.map((caPath) => {
-      fs.existsSync(caPath) ? fs.readFileSync(caPath) : caPath; // eslint-disable-line no-unused-expressions
-    });
+    this.options.ca = list.map((caPath) => fs.existsSync(caPath) ? fs.readFileSync(caPath) : caPath);
   }
   if (useSSL) {
     this.protocol = 'amqps://';


### PR DESCRIPTION
There's a bug where the TLS certificates are not correctly assigned to a `this.options.ca` variable. This is preventing rabbot to correctly instantiate a TLS connection to a server.

This PR fix this